### PR TITLE
Remove unnecessary cloning in getData

### DIFF
--- a/official-ws/nodejs/index.js
+++ b/official-ws/nodejs/index.js
@@ -78,7 +78,7 @@ BitMEXClient.prototype.getData = function(symbol, tableName) {
 
   // Both filters specified, easy return
   if (symbol && tableName) {
-    out = clone(this._data[tableName][symbol] || []);
+    out = this._data[tableName][symbol] || [];
   }
   // Since we're keying by [table][symbol], we have to search deep
   else if (symbol && !tableName) {


### PR DESCRIPTION
There is an extra clone operation in getData in the case where both symbol and table parameters are given.